### PR TITLE
Monitoring Redshift Data API

### DIFF
--- a/app/jobs/call_execute_statement.rb
+++ b/app/jobs/call_execute_statement.rb
@@ -33,7 +33,8 @@ class CallExecuteStatement < ApplicationJob
       database: config[:database],
       db_user: db_user,
       sql: stmt,
-      statement_name: "queuery: #{unload_query.sanitized_note}"
+      statement_name: "queuery: #{unload_query.sanitized_note}",
+      with_event: true
     })
     logger.info "[Redshift Data API] Execute Response: #{api_response}"
     api_response


### PR DESCRIPTION
DescribeStatementによる監視をやめ、EventBridgeによるクエリ実行完了イベントを処理してstatusとするようにするため、まずEventBridgeへ通知がでるようにします
https://docs.aws.amazon.com/ja_jp/redshift/latest/mgmt/data-api-monitoring-events.html