### PR TITLE
Modify to update status of execute statment

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -68,7 +68,7 @@ class Query < ApplicationRecord
     return data_api_status if ENDED_STATUS.include?(data_api_status)
 
     bucket = self.query_execution.bundle.bucket
-    event_log_obj = bucket.object("status/#{data_api_id}.json")
+    event_log_obj = bucket.object("states/#{data_api_id}.json")
 
     Rails.logger.info "[Redshift Data API] check status:#{data_api_id} to s3://#{bucket.name}/#{event_log_obj.key}"
     if event_log_obj.exists?

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'timeout'
 require 'aws-sdk-s3'
 
@@ -72,8 +73,8 @@ class Query < ApplicationRecord
 
     Rails.logger.info "[Redshift Data API] check status:#{data_api_id} to s3://#{bucket.name}/#{event_log_obj.key}"
     if event_log_obj.exists?
-      event_log = event_log_obj.get.body
-      state = event_log.detail.state
+      event_log = JSON.load(event_log_obj.get.body)
+      state = event_log['detail']['state']
     else
       state = 'STARTED'
     end

--- a/app/resources/query_resource.rb
+++ b/app/resources/query_resource.rb
@@ -27,6 +27,8 @@ class QueryResource
       when 'FAILED' then
         'failed'
       when 'ABORTED' then
+        # FIXME: queuery_client can handle only 'success' and 'failed' status (if 'canceled' go to endless loop)
+        # https://github.com/bricolages/queuery_client/blob/master/lib/queuery_client/client.rb
         'failed'
       else
         'unknown'

--- a/app/resources/query_resource.rb
+++ b/app/resources/query_resource.rb
@@ -27,7 +27,7 @@ class QueryResource
       when 'FAILED' then
         'failed'
       when 'ABORTED' then
-        'canceled'
+        'failed'
       else
         'unknown'
       end


### PR DESCRIPTION
Redshift Data APIの結果を待ち続けるため、DescribeStatementを何回も呼び出していました
これによりRedshift Data APIからの応答が悪化し、QueueryのTimeoutが頻発していました

Queueryサーバー側での問い合わせをDescribeStatementではなく、EventBridge経由からのものにします

1. ExecuteStatementを `WithEvent=true` で実行する
2. EventBridge経由で「Redshift Data Statement Status Change 」イベントを検知してlambdaを呼び出し、S3に吐く
3. Queuery側ではS3のオブジェクトが吐かれているか否かで実行ステータスを判断する
    - オブジェクトがあればその中の`state`をそのまま保存する
    - オブジェクトがなければクエリ実行中と判断して `STARTED` （runnning相当）を返す  
    - ただし中断時のreasonなどは含まれていないので、成功時以外は都度DescribeStatementでエラー理由をみにいく