### PR TITLE
Add retry block for ExecuteStatement

### DIFF
--- a/app/jobs/enqueue_bbq_job.rb
+++ b/app/jobs/enqueue_bbq_job.rb
@@ -27,8 +27,8 @@ class EnqueueBbqJob < ApplicationJob
     config = RedshiftBase::connection_db_config.configuration_hash
     logger.info "[Redshift Data API] execute statement: #{job_id} by #{db_user}"
 
-    with_retry do
-      api_response = Aws::RedshiftDataAPIService::Client.new.execute_statement({
+    api_response = with_retry do
+      Aws::RedshiftDataAPIService::Client.new.execute_statement({
         cluster_identifier: config[:cluster_identifier],
         database: config[:database],
         db_user: db_user,

--- a/app/jobs/enqueue_bbq_job.rb
+++ b/app/jobs/enqueue_bbq_job.rb
@@ -26,17 +26,34 @@ class EnqueueBbqJob < ApplicationJob
 
     config = RedshiftBase::connection_db_config.configuration_hash
     logger.info "[Redshift Data API] execute statement: #{job_id} by #{db_user}"
-    api_response = Aws::RedshiftDataAPIService::Client.new.execute_statement({
-      cluster_identifier: config[:cluster_identifier],
-      database: config[:database],
-      db_user: db_user,
-      sql: stmt,
-      statement_name: "queuery: #{unload_query.sanitized_note}",
-      with_event: true
-    })
+
+    with_retry do
+      api_response = Aws::RedshiftDataAPIService::Client.new.execute_statement({
+        cluster_identifier: config[:cluster_identifier],
+        database: config[:database],
+        db_user: db_user,
+        sql: stmt,
+        statement_name: "queuery: #{unload_query.sanitized_note}",
+        with_event: true
+      })
+    end
+
     logger.info "[Redshift Data API] Execute Response: #{api_response}"
     query.data_api_id = api_response.id
     query.save!
+  end
+
+  private def with_retry(max_retry: 5, max_backoff: 8)
+    count = 0
+    begin
+      count += 1
+      yield
+    rescue Seahorse::Client::NetworkingError, Aws::RedshiftDataAPIService::Errors::InternalFailure
+      raise if count > max_retry
+      sleep [2 ** (count - 1), max_backoff].min
+      logger.info "[Redshift Data API] Retry ExecuteStatement: #{count} time"
+      retry
+    end
   end
 
   class SafeUnloadQuery < RedshiftConnector::UnloadQuery


### PR DESCRIPTION
BBQにした後も何度かRedshiftDataAPI周りでエラーが発生しました。
`Seahorse::Client::NetworkingError` か `Aws::RedshiftDataAPIService::Errors::InternalFailure` が発生するとExecuteStatementが実行されず、キューにも入らないためQueueryとしては pending状態で止まります。（[ `data_api_id` が nilになって `SUBMITTED` を返す](https://github.com/bricolages/queuery/blob/6f3d2cf573d7ab2f0f3a0ff6bc8f06c18eff77b7/app/models/query.rb#L67)）

これはSQLのシンタックスエラーとは違い、再実行で直ります。ちなみにExecuteStatementは間違ったSQL文でも投げる事自体は問題なくできます（DescribeStatementでstatusがエラーとして返ってくるだけ）
BBQ側でリトライして対応していましたが、Queuery側で明示的にエラーを区別して対応仕分けたほうが良さそうなのでコード側でリトライ制御します。とりあえず無条件リトライできそうな 2つを対応。
https://docs.aws.amazon.com/zh_cn/redshift-data/latest/APIReference/CommonErrors.html

